### PR TITLE
removed conda install from CI as they are in environment.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
       - shell: bash -el {0}
         run: |
           mamba info
-          mamba install -y -c conda-forge -c cadquery cadquery=master
-          mamba install -y -c conda-forge gmsh
-          mamba install -y pytest
           python -m pytest -v
       - name: Upload output meshes as artifacts for inspection
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I noticed a few lines in the CI that don't need to be there as it looks like the CI installs all the packages in the environment yaml file