### PR TITLE
Adding installation via pip to CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  tests:
+  tests-with-conda-install:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,3 +27,17 @@ jobs:
         with:
           name: exported-meshes
           path: "*.msh"
+
+  tests-with-pip-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          python -m pip install .
+      - name: Run tests
+        run: python -m pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libglu1-mesa
       - name: Install dependencies
         run: |
           python -m pip install .[dev]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   tests-with-conda-install:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tests-with-conda-install:
@@ -38,6 +38,6 @@ jobs:
           python-version: 3.11
       - name: Install dependencies
         run: |
-          python -m pip install .
+          python -m pip install .[dev]
       - name: Run tests
         run: python -m pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "assembly_mesh_plugin"
 version = "0.1.0"
 dependencies = [
   "cadquery",
+  "gmsh",
 ]
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
While making use of the package I noticed it would not work if both cadquery and gmsh were installed via pip (which is our environment).

So I made a small change to the way the cad is passed into gmsh and also added to the CI to ensure the pip installed option works and passes the tests 