### PR TITLE
Added a test for nested cubes

### DIFF
--- a/tests/sample_assemblies.py
+++ b/tests/sample_assemblies.py
@@ -19,13 +19,13 @@ def generate_nested_boxes():
         outside_cube,
         name="outside_cube",
         loc=cq.Location(cq.Vector(0, 0, 0)),
-        color=cq.Color("blue")
+        color=cq.Color("blue"),
     )
     assy.add(
         inside_cube,
         name="inside_cube",
         loc=cq.Location(cq.Vector(0, 0, 0)),
-        color=cq.Color("red")
+        color=cq.Color("red"),
     )
 
     return assy

--- a/tests/sample_assemblies.py
+++ b/tests/sample_assemblies.py
@@ -1,6 +1,36 @@
 import cadquery as cq
 
 
+def generate_nested_boxes():
+    """
+    Generates a simple assembly of two cubes where one is nested inside the other.
+    """
+
+    # Cube that is nested completely inside the other one
+    inside_cube = cq.Workplane().box(5, 5, 5)
+
+    # Use the inside cube to make a void inside the outside cube
+    outside_cube = cq.Workplane().box(10, 10, 10)
+    outside_cube = outside_cube.cut(inside_cube)
+
+    # Create the assembly
+    assy = cq.Assembly()
+    assy.add(
+        outside_cube,
+        name="outside_cube",
+        loc=cq.Location(cq.Vector(0, 0, 0)),
+        color=cq.Color("blue")
+    )
+    assy.add(
+        inside_cube,
+        name="inside_cube",
+        loc=cq.Location(cq.Vector(0, 0, 0)),
+        color=cq.Color("red")
+    )
+
+    return assy
+
+
 def generate_simple_nested_boxes():
     """
     Generates the simplest assembly case where two boxes are nested inside each other.

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -16,8 +16,12 @@ def test_nested_cubes():
     # Create the basic assembly
     assy = generate_nested_boxes()
 
-    # Create a mesh that has all the faces tagged as physical groups
-    assy.saveToGmsh(mesh_path="tagged_nested_boxes.msh")
+    # Convert the assembly to a GMSH mesh
+    gmsh = assy.getTaggedGmsh()
+
+    # Make sure we have the correct number of surfaces
+    surfaces = gmsh.model.getEntities(2)
+    assert len(surfaces) == 18
 
 
 def test_basic_assembly():

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,9 +1,23 @@
 import assembly_mesh_plugin.plugin
 from tests.sample_assemblies import (
+    generate_nested_boxes,
     generate_simple_nested_boxes,
     generate_test_cross_section,
     generate_assembly,
 )
+
+
+def test_nested_cubes():
+    """
+    Tests to make sure that the nested cubes do not cause the correct number of surfaces
+    in the mesh.
+    """
+
+    # Create the basic assembly
+    assy = generate_nested_boxes()
+
+    # Create a mesh that has all the faces tagged as physical groups
+    assy.saveToGmsh(mesh_path="tagged_nested_boxes.msh")
 
 
 def test_basic_assembly():


### PR DESCRIPTION
@shimwell Please check the `tagged_nested_boxes.msh` artifact when the `tests` workflow completes for this PR. You will have to download the entire zip file of artifacts.

This is what I see.

![Screenshot from 2025-01-29 10-37-24](https://github.com/user-attachments/assets/1df1847c-09e4-4bc8-a5e7-8f05aa47f885)
