### PR TITLE
Added tagging of parts within assemblies

### DIFF
--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -1,0 +1,43 @@
+import gmsh
+import assembly_mesh_plugin.plugin
+from tests.sample_assemblies import (
+    generate_nested_boxes,
+    generate_simple_nested_boxes,
+    generate_test_cross_section,
+    generate_assembly,
+)
+
+def test_simple_assembly():
+    """
+    Tests to make sure that the most basic assembly works correctly with tagging.
+    """
+
+    # Create the basic assembly
+    assy = generate_simple_nested_boxes()
+
+    # Create a mesh that has all the faces tagged as physical groups
+    assy.saveToGmsh(mesh_path="tagged_mesh.msh")
+
+    gmsh.initialize()
+
+    gmsh.open("tagged_mesh.msh")
+
+    # Check the solids for the correct tags
+    physical_groups = gmsh.model.getPhysicalGroups(3)
+    for group in physical_groups:
+        # Get the name for the current volume
+        cur_name = gmsh.model.getPhysicalName(3, group[1])
+
+        assert cur_name in ["shell", "insert"]
+
+    # Check the surfaces for the correct tags
+    physical_groups = gmsh.model.getPhysicalGroups(2)
+    for group in physical_groups:
+        # Get the name for this group
+        cur_name = gmsh.model.getPhysicalName(2, group[1])
+
+        # Skip any groups that are not tagged explicitly
+        if "_surface_" in cur_name:
+            continue
+
+        assert cur_name in ["shell_inner-right", "insert_outer-right", "in_contact"]

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -7,6 +7,7 @@ from tests.sample_assemblies import (
     generate_assembly,
 )
 
+
 def test_simple_assembly():
     """
     Tests to make sure that the most basic assembly works correctly with tagging.


### PR DESCRIPTION
@shimwell This is a first attempt at adding volume tagging to the mesh exporter. I'm looking for some feedback. There are two things to note.

1. The current tagging method uses the `name` of the part in the assembly to tag the volumes. Should explicit tagging be used instead (or in addition to)?
2. The feature is currently on all the time, causing the resulting .msh files to have extra physical groups for the part volumes. Will this cause problems? If so, I can make it a parameter.