### PR TITLE
more minimal examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ assy.add(shell, name="shell")
 assy.add(insert, name="insert")
 
 # Get a Gmsh object back with all the tagged faces as physical groups
-gmsh = assy.getTaggedGmsh()
+gmsh_object = assy.getTaggedGmsh()
 
 # Generate the mesh and write it to the file
-gmsh.model.mesh.field.setAsBackgroundMesh(2)
-gmsh.model.mesh.generate(3)
-gmsh.write(mesh_path)
-gmsh.finalize()
+gmsh_object.model.mesh.field.setAsBackgroundMesh(2)
+gmsh_object.model.mesh.generate(3)
+gmsh_object.write("tagged_mesh.msh")
+gmsh_object.finalize()
 ```
-, loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("blue"
+
 ## Tests
 
 These tests are also run in Github Actions, and the meshes which are generated can be viewed as artifacts on the successful `tests` Actions there.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ insert.faces("<X").tag("~in_contact")
 insert.faces(">X").tag("outer-right")
 
 assy = cq.Assembly()
-assy.add(shell, name="shell", loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("red"))
-assy.add(insert, name="insert", loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("blue"))
+assy.add(shell, name="shell")
+assy.add(insert, name="insert")
 
 assy.saveToGmsh(mesh_path="tagged_mesh.msh")
 ```
@@ -77,8 +77,8 @@ insert.faces("<X").tag("~in_contact")
 insert.faces(">X").tag("outer-right")
 
 assy = cq.Assembly()
-assy.add(shell, name="shell", loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("red"))
-assy.add(insert, name="insert", loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("blue"))
+assy.add(shell, name="shell")
+assy.add(insert, name="insert")
 
 # Get a Gmsh object back with all the tagged faces as physical groups
 gmsh = assy.getTaggedGmsh()
@@ -89,7 +89,7 @@ gmsh.model.mesh.generate(3)
 gmsh.write(mesh_path)
 gmsh.finalize()
 ```
-
+, loc=cq.Location(cq.Vector(0, 0, 0)), color=cq.Color("blue"
 ## Tests
 
 These tests are also run in Github Actions, and the meshes which are generated can be viewed as artifacts on the successful `tests` Actions there.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you want more control over the mesh generation and export, you can use the `g
 
 ```python
 import cadquery as cq
-import cadquery_assembly_mesh_plugin.plugin
+import assembly_mesh_plugin.plugin
 import gmsh
 
 shell = cq.Workplane("XY").box(50, 50, 50)


### PR DESCRIPTION
In the readme examples I think loc and color are not used

perhaps best to remove these two to make the example quicker for people to understand

I also corrected the import package name as it had the old package name and I removed an argument that otherwise raises an error in the gmsh.write function
