### PR TITLE
Support for Imprinted Assemblies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9,<=3.12
-  - cadquery=master
   - pytest
   - gmsh
   - python-gmsh

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9,<=3.12
-  - cadquery
+  - cadquery=master
   - pytest
   - gmsh
   - python-gmsh

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,10 @@
 name: tagged-meshes
 channels:
   - conda-forge
+  - cadquery
 dependencies:
   - python>=3.9,<=3.12
+  - cadquery=master
   - pytest
   - gmsh
   - python-gmsh

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -79,3 +79,34 @@ def test_subshape_assembly():
             continue
 
         assert cur_name in ["cube_1_cube_1_top_face"]
+
+
+def test_imprinted_assembly():
+    # Create the basic assembly
+    assy = generate_simple_nested_boxes()
+
+    assy.assemblyToImprintedGmsh("tagged_imprinted_mesh.msh")
+
+    gmsh.initialize()
+
+    gmsh.open("tagged_imprinted_mesh.msh")
+
+    # Check the solids for the correct tags
+    physical_groups = gmsh.model.getPhysicalGroups(3)
+    for group in physical_groups:
+        # Get the name for the current volume
+        cur_name = gmsh.model.getPhysicalName(3, group[1])
+
+        assert cur_name in ["shell", "insert"]
+
+    # Check the surfaces for the correct tags
+    physical_groups = gmsh.model.getPhysicalGroups(2)
+    for group in physical_groups:
+        # Get the name for this group
+        cur_name = gmsh.model.getPhysicalName(2, group[1])
+
+        # Skip any groups that are not tagged explicitly
+        if "_surface_" in cur_name:
+            continue
+
+        assert cur_name in ["shell_inner-right", "insert_outer-right", "in_contact"]


### PR DESCRIPTION
@shimwell Please take a look and see if this addresses #17 . Please note the new test, and I have attached the sample msh file that is generated by that test.

[tagged_imprinted_mesh.msh.zip](https://github.com/user-attachments/files/20067274/tagged_imprinted_mesh.msh.zip)

I can restructure the new code if desired. This method combines creating the mesh and writing it unlike the previous methods. I also do not currently include physical groups for non-tagged surfaces. I cannot remember if we've discussed whether physical groups for non-tagged surfaces are important.

This method also does not support subshapes, but that will be easy enough to add if this method seems like it will work for you.